### PR TITLE
Update distanceofnodes.cpp

### DIFF
--- a/C++/distanceofnodes.cpp
+++ b/C++/distanceofnodes.cpp
@@ -32,7 +32,7 @@ ll lca(ll u, ll v) {
     }
 
     // Lift u up until it's the same depth as v
-    ll diff = depth[u] - depth[v]; // first we will bring them to the same level 
+    ll diff = depth[u] - depth[v];
     for (ll i = 0; i < LOG; i++) {
         if ((diff >> i) & 1) { // If the i-th bit of diff is set, lift u by 2^i
             u = up[u][i];
@@ -50,15 +50,15 @@ ll lca(ll u, ll v) {
     }
 
     // The parent of u (or v) is the LCA
-    return up[u][0]; // once up[u][i] == up[v][i] then keep subtracting i until it becomes 0
+    return up[u][0];
 }
 
 void run() {
     ll n, q;
     cin >> n >> q;
 
-    for(ll i=2;i<=n;i++){
-        ll u,v;
+    for (ll i = 1; i <= n - 1; i++) {
+        ll u, v;
         cin >> u >> v;
         adj[u].push_back(v);
         adj[v].push_back(u);
@@ -70,8 +70,9 @@ void run() {
     while (q--) {
         ll u, v;
         cin >> u >> v;
-        ll ans=abs(depth[u]-depth[lca(u,v)])+abs(depth[v]-depth[lca(u,v)]);
-        cout<<ans<<nl;
+        ll ancestor = lca(u, v);
+        ll ans = (depth[u] - depth[ancestor]) + (depth[v] - depth[ancestor]);
+        cout << ans << nl;
     }
 }
 


### PR DESCRIPTION
This C++ implementation efficiently computes the Lowest Common Ancestor (LCA) of two nodes in a tree using the binary lifting technique. It utilizes depth-first search (DFS) to preprocess the tree and build a table of ancestors for each node, allowing for quick retrieval of the LCA in logarithmic time. The solution handles multiple queries to determine the distance between pairs of nodes, optimizing both time and space complexity. This approach is particularly useful in competitive programming and scenarios involving dynamic trees.






